### PR TITLE
Add lc_env to encrypt environment variables at compile time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,7 @@ checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "litcrypt"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "expectest",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "litcrypt"
 authors = ['Robin Syihab (r@ansvia.com)']
-version = "0.3.0"
+version = "0.4.0"
 description = "Let's encrypt your string statically during compile time"
 license = "Apache-2.0"
 repository = "https://github.com/anvie/litcrypt.rs"

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,3 @@
 fn main() {
-    println!("cargo:rustc-env=LITCRYPT_ENCRYPT_KEY=MY-SECRET-SPELL");  // I couldn't get this to work without passing this as an environment variable
     println!("cargo:rustc-env=SECRET_ENV=Shhhhhh");
 }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("cargo:rustc-env=LITCRYPT_ENCRYPT_KEY=MY-SECRET-SPELL");  // I couldn't get this to work without passing this as an environment variable
+    println!("cargo:rustc-env=SECRET_ENV=Shhhhhh");
+}

--- a/src/litcrypt.rs
+++ b/src/litcrypt.rs
@@ -175,6 +175,28 @@ pub fn lc(tokens: TokenStream) -> TokenStream {
         }
     }
     something = String::from(&something[1..something.len() - 1]);
+    
+    encrypt_string(something)
+}
+
+/// Encrypts an environment variable at compile time with the key set before, via calling [`use_litcrypt!`].
+#[proc_macro]
+pub fn lc_env(tokens: TokenStream) -> TokenStream {
+    let mut var_name = String::from("");
+
+    for tok in tokens {
+        var_name = match tok {
+            TokenTree::Literal(lit) => lit.to_string(),
+            _ => "<unknown>".to_owned(),
+        }
+    }
+
+    var_name = String::from(&var_name[1..var_name.len() - 1]);
+
+    encrypt_string(env::var(var_name).unwrap_or(String::from("unknown")))
+}
+
+fn encrypt_string(something: String) -> TokenStream {
     let magic_spell = get_magic_spell();
     let encrypt_key = xor::xor(&magic_spell, b"l33t");
     let encrypted = xor::xor(&something.as_bytes(), &encrypt_key);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -12,3 +12,8 @@ pub fn test_literal1() {
 pub fn test_literal2() {
     assert_eq!(lc!("Very secret word"), "Very secret word");
 }
+
+#[test]
+pub fn test_env() {
+    assert_eq!(lc_env!("SECRET_ENV"), "Shhhhhh");
+}


### PR DESCRIPTION
This bumps the version to 0.4.0 and notably adds a macro to load environment variables and encrypt them as I could find no way to achieve that with the current implementation. Its 7am and I haven't slept, so I could likely have made a mistake, but it seems to work. I added a test to confirm and a build.rs file to pass an environment variable in at compile time. I had to add a LITCRYPT_ENCRYPT_KEY environment variable as well because it would not compile without it, not sure why.

I needed this feature for a project I'm working on, I hope it meets your standards.