### PR TITLE
Support for raw strings for the lc!() macro.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,16 +35,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
-name = "litcrypt"
-version = "0.4.0"
+name = "litcrypt2"
+version = "0.1.0"
 dependencies = [
  "expectest",
+ "lazy_static",
  "proc-macro2",
  "quote",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "litcrypt"
-authors = ['Robin Syihab (r@ansvia.com)']
-version = "0.4.0"
+name = "litcrypt2"
+authors = ['Robin Syihab (r@ansvia.com)', 'Kurosh Dabbagh Escalante (@_Kudaes_)']
+version = "0.1.0"
 description = "Let's encrypt your string statically during compile time"
 license = "Apache-2.0"
-repository = "https://github.com/anvie/litcrypt.rs"
+repository = "https://github.com/Kudaes/litcrypt.rs"
 readme = "README.md"
-keywords = ["litcrypt", "encrypt", "compile"]
+keywords = ["litcrypt", "encrypt", "obfuscation"]
 
 [lib]
 proc-macro = true

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
-LITCRYPT [![Build Status](https://travis-ci.org/anvie/litcrypt.rs.svg?branch=master)](https://travis-ci.org/anvie/litcrypt.rs) ![Crates.io](https://img.shields.io/crates/v/litcrypt)
+LITCRYPT2 
 ===========
 
-Is a short name of "Literal Encryption", a Rust proc macro that encrypts text using a basic XOR method. It protect plain text from static analysis tools and helps keep your important app safe from cracking activity.
+It's a short name of "Literal Encryption", a Rust proc macro that encrypts text using a basic XOR method. It protect plain text from static analysis tools and helps keep your important app safe from cracking activity.
 
-LITCRYPT encrypts strings when compiling, keeping them encrypted in both disk and memory while running, and only decrypting them when needed.
+LITCRYPT2 encrypts strings when compiling, keeping them encrypted in both disk and memory while running, and only decrypting them when needed.
+
+This crate is just a maintained and updated fork of the original crate, **LITCRYPT** by **Robin Syihab (r@ansvia.com)**.
 
 USAGE
 -----
@@ -12,28 +14,34 @@ Dependencies:
 
 ```rust
 [dependencies]
-litcrypt = "0.3"
+litcrypt2 = "0.1"
 ```
 
 Example:
 
 ```rust
 #[macro_use]
-extern crate litcrypt;
+extern crate litcrypt2;
 
 use_litcrypt!();
 
-fn main(){
+fn main()
+{
     println!("his name is: {}", lc!("Voldemort"));
+}
+
+fn raw_string()
+{
+    println!("The command line console can be found in the path {}", lc!(r"C:\Windows\System32\cmd.exe"));
 }
 ```
 
 `use_litcrypt!` macro call should be called first for initialization before you can
-use `lc!` macro function. The first parameter is your secret key used for encrypt your
-literal string. This key is also encrypted and will not visible under static analyzer.
+use `lc!` macro function. 
 
-Please take note that you need to set your encryption key using environment variable 
-`LITCRYPT_ENCRYPT_KEY` before compile:
+Please take note that you can set your encryption key to a specific value using the environment variable 
+`LITCRYPT_ENCRYPT_KEY` before compile. In case that you don't set this environment variable, the crate
+will generate a random encryption key at compilation time:
 e.g:
 
     $ export LITCRYPT_ENCRYPT_KEY="myverysuperdupermegaultrasecretkey"
@@ -50,5 +58,3 @@ like Hexeditor etc.
 For working example code see `./examples` directory, and test using:
 
     $ cargo run --example simple
-
-[] Robin.

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -3,7 +3,7 @@
 // the encrypted one will not print anything (just blank).
 
 #[macro_use]
-extern crate litcrypt;
+extern crate litcrypt2;
 
 use_litcrypt!();
 

--- a/src/litcrypt.rs
+++ b/src/litcrypt.rs
@@ -179,11 +179,23 @@ pub fn lc(tokens: TokenStream) -> TokenStream {
     let mut something = String::from("");
     for tok in tokens {
         something = match tok {
-            TokenTree::Literal(lit) => lit.to_string(),
+            TokenTree::Literal(lit) => {
+                let mut lit_str: String = lit.to_string(); 
+                let first_occurrence = lit_str.find("\"");
+                let last_occurrence = lit_str.rfind("\"");
+
+                if !first_occurrence.is_none() && !last_occurrence.is_none(){
+                    lit_str = lit_str[first_occurrence.unwrap() + 1..last_occurrence.unwrap()].to_string();
+                }
+                else {
+                    lit_str = lit_str[1..lit_str.len() - 1].to_string();
+                }
+
+                lit_str
+            },
             _ => "<unknown>".to_owned(),
         }
     }
-    something = String::from(&something[1..something.len() - 1]);
     
     encrypt_string(something)
 }

--- a/src/litcrypt.rs
+++ b/src/litcrypt.rs
@@ -163,7 +163,7 @@ pub fn use_litcrypt(_tokens: TokenStream) -> TokenStream {
         }
     };
     let result = {
-        let ekey = xor::xor(&magic_spell, b"l33t");
+        let ekey = xor::xor(&magic_spell, b"ESJCTVgWH5HQFza7GdRx");
         let ekey = Literal::byte_string(&ekey);
         quote! {
             static LITCRYPT_ENCRYPT_KEY: &'static [u8] = #ekey;
@@ -219,7 +219,7 @@ pub fn lc_env(tokens: TokenStream) -> TokenStream {
 
 fn encrypt_string(something: String) -> TokenStream {
     let magic_spell = get_magic_spell();
-    let encrypt_key = xor::xor(&magic_spell, b"l33t");
+    let encrypt_key = xor::xor(&magic_spell, b"ESJCTVgWH5HQFza7GdRx");
     let encrypted = xor::xor(&something.as_bytes(), &encrypt_key);
     let encrypted = Literal::byte_string(&encrypted);
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,5 +1,5 @@
 #[macro_use]
-extern crate litcrypt;
+extern crate litcrypt2;
 
 use_litcrypt!("MY-SECRET-SPELL");
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -17,3 +17,18 @@ pub fn test_literal2() {
 pub fn test_env() {
     assert_eq!(lc_env!("SECRET_ENV"), "Shhhhhh");
 }
+
+#[test]
+pub fn test_raw1() {
+    assert_eq!(lc!(r"c:\windows\system32"), r"c:\windows\system32");
+}
+
+#[test]
+pub fn test_raw2() {
+    assert_eq!(lc!(r#"\\machine\share"#), r#"\\machine\share"#);
+}
+
+#[test]
+pub fn test_raw3() {
+    assert_eq!(lc!(r###"String with ##"###), r###"String with ##"###);
+}


### PR DESCRIPTION
Raw strings are now properly encrypted.
Any valid rust syntax for raw strings can be used with the lc!() macro (r"", r#"", r##""##, etc.). 
Added 3 new tests to check this feature.